### PR TITLE
ci: add Release Please and PyPI publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Build package
+        run: uv build
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/yet-another-figma-mcp/
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+  publish-pypi:
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/yet-another-figma-mcp/
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,16 +87,55 @@ uv run pytest
 1. リント・型チェック・テストがパスすることを確認
 1. プルリクエストを作成
 
-### コミットメッセージ
+### コミットメッセージ（Conventional Commits）
 
-意味のある簡潔なコミットメッセージを書いてください:
+本プロジェクトでは [Conventional Commits](https://www.conventionalcommits.org/) 形式を採用しています。
+これにより、[Release Please](https://github.com/googleapis/release-please) による自動リリースが可能になります。
 
+#### フォーマット
+
+```text
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
 ```
+
+#### タイプ一覧
+
+| タイプ     | 説明                                                 | リリースへの影響         |
+| ---------- | ---------------------------------------------------- | ------------------------ |
+| `feat`     | 新機能の追加                                         | マイナーバージョンアップ |
+| `fix`      | バグ修正                                             | パッチバージョンアップ   |
+| `docs`     | ドキュメントのみの変更                               | リリースなし             |
+| `style`    | コードの意味に影響しない変更（空白、フォーマット等） | リリースなし             |
+| `refactor` | バグ修正でも機能追加でもないコード変更               | リリースなし             |
+| `perf`     | パフォーマンス改善                                   | パッチバージョンアップ   |
+| `test`     | テストの追加・修正                                   | リリースなし             |
+| `chore`    | ビルドプロセスやツールの変更                         | リリースなし             |
+| `ci`       | CI 設定の変更                                        | リリースなし             |
+| `security` | セキュリティ修正                                     | パッチバージョンアップ   |
+
+#### 破壊的変更
+
+破壊的変更がある場合は `!` を追加するか、フッターに `BREAKING CHANGE:` を記述します：
+
+```text
+feat!: API の互換性を破壊する変更
+
+BREAKING CHANGE: get_cached_figma_file の戻り値の構造が変更されました
+```
+
+#### 例
+
+```text
 feat: ノード検索機能を追加
 fix: キャッシュ読み込み時のエラーを修正
 docs: README にセットアップ手順を追加
 refactor: CacheStore クラスを整理
 test: search_figma_nodes_by_name のテストを追加
+ci: Release Please ワークフローを追加
 ```
 
 ## ディレクトリ構造


### PR DESCRIPTION
## Summary
- Add `release-please.yml` for automated release PR creation
- Add `publish.yml` for PyPI/TestPyPI publishing on release
- Update `CONTRIBUTING.md` with Conventional Commits guide

## Workflow

```
Conventional Commits → Release Please PR → Merge → Tag → PyPI Publish
```

1. **release-please.yml**: main への push で自動的にリリース PR を作成/更新
2. **publish.yml**: リリース公開時に TestPyPI → PyPI へ公開

## Setup Required (マージ後に手動設定が必要)

### 1. GitHub Environments
Settings → Environments で以下を作成:
- `testpypi`
- `pypi`

### 2. PyPI/TestPyPI Trusted Publisher
各サイトで Trusted Publisher を設定:
- **Owner**: `yk-lab`
- **Repository**: `yet-another-figma-mcp`
- **Workflow**: `publish.yml`
- **Environment**: `pypi` / `testpypi`

### 3. Branch Protection (推奨)
Settings → Branches → Add branch ruleset で main ブランチを保護

Closes #23
Closes #13