### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/yk-lab/yet-another-figma-mcp/security/code-scanning/1](https://github.com/yk-lab/yet-another-figma-mcp/security/code-scanning/1)

To address this issue, we need to add a `permissions` key to the workflow, setting it to the minimum necessary permissions. According to the default suggestion, the most conservative setting is `permissions: { contents: read }`, which grants only read access to repository contents. This should be adequate for most CI workflows that do not perform write operations via the GITHUB_TOKEN. We should add this block at the workflow root (immediately under `name:` or `on:`), so it covers all jobs unless a more permissive override is needed in specific jobs.

- Add a `permissions` block at the workflow root, after the `name` or `on` fields.
- The only line to add is:
  ```yaml
  permissions:
    contents: read
  ```
- No removals or changes to existing functionality are required.
- No imports, variable definitions, or method changes are involved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
