### PR TITLE
fix(tools): 検索・一覧ツールが無効なfile_idでエラー辞書を返すように統一

### DIFF
--- a/src/yet_another_figma_mcp/tools/handlers.py
+++ b/src/yet_another_figma_mcp/tools/handlers.py
@@ -27,6 +27,18 @@ def _handle_invalid_file_id(file_id: str) -> dict[str, Any]:
     }
 
 
+def _handle_file_not_found(file_id: str) -> dict[str, Any]:
+    """Generate error response for file not found in cache"""
+    return {
+        "error": "file_not_found",
+        "message": (
+            f"File '{file_id}' not found in cache. "
+            f"Run 'yet-another-figma-mcp cache -f {file_id}' to cache it first."
+        ),
+        "file_id": file_id,
+    }
+
+
 def _effective_depth(node_id: str, by_id: dict[str, dict[str, Any]]) -> int:
     """Count non-SECTION ancestors (inclusive) by walking the parent_id chain.
 
@@ -115,14 +127,7 @@ def get_cached_figma_file(store: CacheStore, file_id: str) -> dict[str, Any]:
 
     index = store.get_index(file_id)
     if not index:
-        return {
-            "error": "file_not_found",
-            "message": (
-                f"File '{file_id}' not found in cache. "
-                f"Run 'yet-another-figma-mcp cache -f {file_id}' to cache it first."
-            ),
-            "file_id": file_id,
-        }
+        return _handle_file_not_found(file_id)
 
     file_data = store.get_file(file_id)
     if not file_data:
@@ -186,14 +191,7 @@ def get_cached_figma_node(
 
     file_data = store.get_file(file_id)
     if not file_data:
-        return {
-            "error": "file_not_found",
-            "message": (
-                f"File '{file_id}' not found in cache. "
-                f"Run 'yet-another-figma-mcp cache -f {file_id}' to cache it first."
-            ),
-            "file_id": file_id,
-        }
+        return _handle_file_not_found(file_id)
 
     def find_node(node: dict[str, Any], target_id: str) -> dict[str, Any] | None:
         """Recursively search for a node by ID in the node tree"""
@@ -234,7 +232,7 @@ def search_figma_nodes_by_name(
     match_mode: Literal["exact", "partial"] = "exact",
     limit: int | None = None,
     ignore_case: bool = False,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | dict[str, Any]:
     """Search nodes by name
 
     Args:
@@ -247,16 +245,16 @@ def search_figma_nodes_by_name(
             Partial mode is always case-insensitive.
 
     Returns:
-        List of matching nodes
+        List of matching nodes. Contains 'error' field on error.
     """
     try:
         validate_file_id(file_id)
     except InvalidFileIdError:
-        return []
+        return _handle_invalid_file_id(file_id)
 
     index = store.get_index(file_id)
     if not index:
-        return []
+        return _handle_file_not_found(file_id)
 
     by_name = index.get("by_name", {})
     by_id = index.get("by_id", {})
@@ -275,7 +273,7 @@ def search_figma_frames_by_title(
     match_mode: Literal["exact", "partial"] = "exact",
     limit: int | None = None,
     ignore_case: bool = False,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | dict[str, Any]:
     """Search frame nodes by title
 
     Args:
@@ -288,16 +286,16 @@ def search_figma_frames_by_title(
             Partial mode is always case-insensitive.
 
     Returns:
-        List of matching frame nodes
+        List of matching frame nodes. Contains 'error' field on error.
     """
     try:
         validate_file_id(file_id)
     except InvalidFileIdError:
-        return []
+        return _handle_invalid_file_id(file_id)
 
     index = store.get_index(file_id)
     if not index:
-        return []
+        return _handle_file_not_found(file_id)
 
     by_frame_title = index.get("by_frame_title", {})
     by_id = index.get("by_id", {})
@@ -309,16 +307,20 @@ def search_figma_frames_by_title(
     return results
 
 
-def list_figma_frames(store: CacheStore, file_id: str) -> list[dict[str, Any]]:
-    """List top-level frames in the file"""
+def list_figma_frames(store: CacheStore, file_id: str) -> list[dict[str, Any]] | dict[str, Any]:
+    """List top-level frames in the file
+
+    Returns:
+        List of top-level frames. Contains 'error' field on error.
+    """
     try:
         validate_file_id(file_id)
     except InvalidFileIdError:
-        return []
+        return _handle_invalid_file_id(file_id)
 
     index = store.get_index(file_id)
     if not index:
-        return []
+        return _handle_file_not_found(file_id)
 
     results: list[dict[str, Any]] = []
     by_id = index.get("by_id", {})

--- a/tests/integration/cache_flow_test.py
+++ b/tests/integration/cache_flow_test.py
@@ -78,6 +78,7 @@ class TestCacheFlowIntegration:
             store, file_id, name="Primary Button", match_mode="exact"
         )
 
+        assert isinstance(results, list)
         assert len(results) == 1
         assert results[0]["name"] == "Primary Button"
 
@@ -88,6 +89,7 @@ class TestCacheFlowIntegration:
         results = search_figma_nodes_by_name(store, file_id, name="Button", match_mode="partial")
 
         # Primary Button, Secondary Button, Icon Button, Submit Button, Menu Button, Profile Button
+        assert isinstance(results, list)
         assert len(results) >= 3
         for node in results:
             assert "Button" in node["name"]
@@ -102,6 +104,7 @@ class TestCacheFlowIntegration:
             store, file_id, name="button", match_mode="partial", ignore_case=True
         )
 
+        assert isinstance(results, list)
         assert len(results) >= 3
 
     def test_full_flow_search_by_name_multibyte(self, setup_cache: tuple[CacheStore, str]) -> None:
@@ -112,11 +115,13 @@ class TestCacheFlowIntegration:
         results = search_figma_nodes_by_name(
             store, file_id, name="プライマリボタン", match_mode="exact"
         )
+        assert isinstance(results, list)
         assert len(results) == 1
         assert results[0]["name"] == "プライマリボタン"
 
         # 日本語名の部分一致検索
         results = search_figma_nodes_by_name(store, file_id, name="ボタン", match_mode="partial")
+        assert isinstance(results, list)
         assert len(results) >= 2
         for node in results:
             assert "ボタン" in node["name"]
@@ -130,6 +135,7 @@ class TestCacheFlowIntegration:
         results = search_figma_frames_by_title(
             store, file_id, title="入力フィールド", match_mode="exact"
         )
+        assert isinstance(results, list)
         assert len(results) == 1
         assert results[0]["name"] == "入力フィールド"
 
@@ -139,6 +145,7 @@ class TestCacheFlowIntegration:
 
         results = search_figma_frames_by_title(store, file_id, title="Login", match_mode="partial")
 
+        assert isinstance(results, list)
         assert len(results) >= 1
         frame_names = [f["name"] for f in results]
         assert "Login Screen" in frame_names
@@ -149,6 +156,7 @@ class TestCacheFlowIntegration:
 
         results = list_figma_frames(store, file_id)
 
+        assert isinstance(results, list)
         frame_names = [f["name"] for f in results]
         # トップレベルフレームが含まれている
         assert "Buttons" in frame_names
@@ -162,6 +170,7 @@ class TestCacheFlowIntegration:
 
         # まずフレーム一覧を取得
         frames = list_figma_frames(store, file_id)
+        assert isinstance(frames, list)
         assert len(frames) > 0
 
         # Buttons フレームを見つける
@@ -233,6 +242,7 @@ class TestMultipleFilesIntegration:
             results = search_figma_nodes_by_name(
                 store, file_id, name="Button", match_mode="partial"
             )
+            assert isinstance(results, list)
             assert len(results) >= 3
 
     def test_nonexistent_file_returns_error(
@@ -295,6 +305,7 @@ class TestIndexConsistency:
 
         results = list_figma_frames(store, file_id)
 
+        assert isinstance(results, list)
         # 全結果が FRAME であることを確認
         for frame in results:
             # list_figma_frames は type を含まないので、ノードを直接取得して確認

--- a/tests/integration/mcp_server_test.py
+++ b/tests/integration/mcp_server_test.py
@@ -277,6 +277,7 @@ class TestMCPServerToolCallsDirect:
         store = get_store()
         results = search_figma_nodes_by_name(store, file_id, name="Button", match_mode="partial")
 
+        assert isinstance(results, list)
         assert len(results) >= 3
 
     def test_search_figma_nodes_with_ignore_case_direct(
@@ -290,6 +291,7 @@ class TestMCPServerToolCallsDirect:
             store, file_id, name="button", match_mode="partial", ignore_case=True
         )
 
+        assert isinstance(results, list)
         assert len(results) >= 3
 
     def test_search_figma_frames_by_title_direct(self, server_with_cache: tuple[Any, str]) -> None:
@@ -299,6 +301,7 @@ class TestMCPServerToolCallsDirect:
         store = get_store()
         results = search_figma_frames_by_title(store, file_id, title="Login", match_mode="partial")
 
+        assert isinstance(results, list)
         frame_names = [f["name"] for f in results]
         assert "Login Screen" in frame_names
 
@@ -309,6 +312,7 @@ class TestMCPServerToolCallsDirect:
         store = get_store()
         results = list_figma_frames(store, file_id)
 
+        assert isinstance(results, list)
         frame_names = [f["name"] for f in results]
         assert "Buttons" in frame_names
         assert "Login Screen" in frame_names

--- a/tests/tools/handlers_test.py
+++ b/tests/tools/handlers_test.py
@@ -305,34 +305,42 @@ class TestGetCachedFigmaNode:
 
 
 class TestSearchFigmaNodesByName:
-    def test_returns_empty_for_invalid_file_id(self, store_with_data: CacheStore) -> None:
-        """無効な file_id は空リストを返す"""
-        results = search_figma_nodes_by_name(store_with_data, "../invalid", "Button", "exact")
-        assert results == []
+    def test_returns_error_for_invalid_file_id(self, store_with_data: CacheStore) -> None:
+        """無効な file_id はエラーを返す"""
+        result = search_figma_nodes_by_name(store_with_data, "../invalid", "Button", "exact")
+        assert isinstance(result, dict)
+        assert result["error"] == "invalid_file_id"
+        assert result["file_id"] == "../invalid"
 
-    def test_returns_empty_for_missing_index(self, store_with_data: CacheStore) -> None:
-        """インデックスがない場合は空リストを返す"""
-        results = search_figma_nodes_by_name(store_with_data, "nonexistent", "Button", "exact")
-        assert results == []
+    def test_returns_error_for_missing_file(self, store_with_data: CacheStore) -> None:
+        """キャッシュにないファイルはエラーを返す"""
+        result = search_figma_nodes_by_name(store_with_data, "nonexistent", "Button", "exact")
+        assert isinstance(result, dict)
+        assert result["error"] == "file_not_found"
+        assert result["file_id"] == "nonexistent"
 
     def test_exact_match(self, store_with_data: CacheStore) -> None:
         results = search_figma_nodes_by_name(store_with_data, "test123", "Primary Button", "exact")
+        assert isinstance(results, list)
         assert len(results) == 1
         assert results[0]["name"] == "Primary Button"
 
     def test_partial_match(self, store_with_data: CacheStore) -> None:
         results = search_figma_nodes_by_name(store_with_data, "test123", "Button", "partial")
+        assert isinstance(results, list)
         assert len(results) >= 1
 
     def test_limit(self, store_with_data: CacheStore) -> None:
         results = search_figma_nodes_by_name(
             store_with_data, "test123", "Screen", "partial", limit=1
         )
+        assert isinstance(results, list)
         assert len(results) == 1
 
     def test_exact_match_case_sensitive_by_default(self, store_with_data: CacheStore) -> None:
         """exact モードはデフォルトで大文字小文字を区別する"""
         results = search_figma_nodes_by_name(store_with_data, "test123", "primary button", "exact")
+        assert isinstance(results, list)
         assert len(results) == 0
 
     def test_exact_match_ignore_case(self, store_with_data: CacheStore) -> None:
@@ -340,46 +348,56 @@ class TestSearchFigmaNodesByName:
         results = search_figma_nodes_by_name(
             store_with_data, "test123", "primary button", "exact", ignore_case=True
         )
+        assert isinstance(results, list)
         assert len(results) == 1
         assert results[0]["name"] == "Primary Button"
 
     def test_partial_match_always_case_insensitive(self, store_with_data: CacheStore) -> None:
         """partial モードは常に大文字小文字を無視する"""
         results = search_figma_nodes_by_name(store_with_data, "test123", "button", "partial")
+        assert isinstance(results, list)
         assert len(results) >= 1
         assert any(r["name"] == "Primary Button" for r in results)
 
 
 class TestSearchFigmaFramesByTitle:
-    def test_returns_empty_for_invalid_file_id(self, store_with_data: CacheStore) -> None:
-        """無効な file_id は空リストを返す"""
-        results = search_figma_frames_by_title(store_with_data, "../invalid", "Screen", "exact")
-        assert results == []
+    def test_returns_error_for_invalid_file_id(self, store_with_data: CacheStore) -> None:
+        """無効な file_id はエラーを返す"""
+        result = search_figma_frames_by_title(store_with_data, "../invalid", "Screen", "exact")
+        assert isinstance(result, dict)
+        assert result["error"] == "invalid_file_id"
+        assert result["file_id"] == "../invalid"
 
-    def test_returns_empty_for_missing_index(self, store_with_data: CacheStore) -> None:
-        """インデックスがない場合は空リストを返す"""
-        results = search_figma_frames_by_title(store_with_data, "nonexistent", "Screen", "exact")
-        assert results == []
+    def test_returns_error_for_missing_file(self, store_with_data: CacheStore) -> None:
+        """キャッシュにないファイルはエラーを返す"""
+        result = search_figma_frames_by_title(store_with_data, "nonexistent", "Screen", "exact")
+        assert isinstance(result, dict)
+        assert result["error"] == "file_not_found"
+        assert result["file_id"] == "nonexistent"
 
     def test_limit(self, store_with_data: CacheStore) -> None:
         """limit パラメータで取得件数を制限できる"""
         results = search_figma_frames_by_title(
             store_with_data, "test123", "Screen", "partial", limit=1
         )
+        assert isinstance(results, list)
         assert len(results) == 1
 
     def test_exact_match(self, store_with_data: CacheStore) -> None:
         results = search_figma_frames_by_title(store_with_data, "test123", "Login Screen", "exact")
+        assert isinstance(results, list)
         assert len(results) == 1
         assert results[0]["name"] == "Login Screen"
 
     def test_partial_match(self, store_with_data: CacheStore) -> None:
         results = search_figma_frames_by_title(store_with_data, "test123", "Screen", "partial")
+        assert isinstance(results, list)
         assert len(results) == 2  # Login Screen, Sign Up Screen
 
     def test_exact_match_case_sensitive_by_default(self, store_with_data: CacheStore) -> None:
         """exact モードはデフォルトで大文字小文字を区別する"""
         results = search_figma_frames_by_title(store_with_data, "test123", "login screen", "exact")
+        assert isinstance(results, list)
         assert len(results) == 0
 
     def test_exact_match_ignore_case(self, store_with_data: CacheStore) -> None:
@@ -387,12 +405,14 @@ class TestSearchFigmaFramesByTitle:
         results = search_figma_frames_by_title(
             store_with_data, "test123", "login screen", "exact", ignore_case=True
         )
+        assert isinstance(results, list)
         assert len(results) == 1
         assert results[0]["name"] == "Login Screen"
 
     def test_partial_match_always_case_insensitive(self, store_with_data: CacheStore) -> None:
         """partial モードは常に大文字小文字を無視する"""
         results = search_figma_frames_by_title(store_with_data, "test123", "screen", "partial")
+        assert isinstance(results, list)
         assert len(results) == 2
         names = [r["name"] for r in results]
         assert "Login Screen" in names
@@ -400,18 +420,23 @@ class TestSearchFigmaFramesByTitle:
 
 
 class TestListFigmaFrames:
-    def test_returns_empty_for_invalid_file_id(self, store_with_data: CacheStore) -> None:
-        """無効な file_id は空リストを返す"""
-        results = list_figma_frames(store_with_data, "../invalid")
-        assert results == []
+    def test_returns_error_for_invalid_file_id(self, store_with_data: CacheStore) -> None:
+        """無効な file_id はエラーを返す"""
+        result = list_figma_frames(store_with_data, "../invalid")
+        assert isinstance(result, dict)
+        assert result["error"] == "invalid_file_id"
+        assert result["file_id"] == "../invalid"
 
-    def test_returns_empty_for_missing_index(self, store_with_data: CacheStore) -> None:
-        """インデックスがない場合は空リストを返す"""
-        results = list_figma_frames(store_with_data, "nonexistent")
-        assert results == []
+    def test_returns_error_for_missing_file(self, store_with_data: CacheStore) -> None:
+        """キャッシュにないファイルはエラーを返す"""
+        result = list_figma_frames(store_with_data, "nonexistent")
+        assert isinstance(result, dict)
+        assert result["error"] == "file_not_found"
+        assert result["file_id"] == "nonexistent"
 
     def test_lists_top_frames(self, store_with_data: CacheStore) -> None:
         results = list_figma_frames(store_with_data, "test123")
+        assert isinstance(results, list)
         assert len(results) == 2
         names = [r["name"] for r in results]
         assert "Login Screen" in names
@@ -420,6 +445,7 @@ class TestListFigmaFrames:
     def test_lists_frames_inside_sections(self, store_with_sections: CacheStore) -> None:
         """SECTION 内・外のフレームが混在してもリストされる"""
         results = list_figma_frames(store_with_sections, "sections123")
+        assert isinstance(results, list)
         assert len(results) == 4
         names = [r["name"] for r in results]
         assert "Login Screen" in names
@@ -430,6 +456,7 @@ class TestListFigmaFrames:
     def test_section_nodes_not_listed_as_frames(self, store_with_sections: CacheStore) -> None:
         """SECTION ノード自体はフレーム一覧に含まれない"""
         results = list_figma_frames(store_with_sections, "sections123")
+        assert isinstance(results, list)
         names = [r["name"] for r in results]
         assert "Auth Section" not in names
         assert "Outer Section" not in names


### PR DESCRIPTION
## Summary
- `search_figma_nodes_by_name`, `search_figma_frames_by_title`, `list_figma_frames` が無効な file_id やキャッシュ未登録ファイルに対して空リスト `[]` ではなくエラー辞書を返すように変更
- `_handle_file_not_found()` ヘルパーを追加し、既存の `get_cached_figma_file` / `get_cached_figma_node` のインライン定義も統一
- 全5ツールのエラーレスポンスが一貫した形式に

## 変更内容
- **`invalid_file_id`**: 3関数で `return []` → `return _handle_invalid_file_id(file_id)`
- **`file_not_found`**: 3関数で `return []` → `return _handle_file_not_found(file_id)`
- 戻り値型を `list[dict[str, Any]]` → `list[dict[str, Any]] | dict[str, Any]` に変更
- テストで `assert isinstance(results, list)` による型絞り込みを追加

Closes #90

## Test plan
- [x] 全249テスト通過
- [x] pyright 0 errors
- [x] 無効 file_id でエラー辞書が返ることを確認（3関数 x 2パターン = 6テスト）
- [x] 正常系の動作に変更なし