### PR TITLE
ci: ワークフローにtimeout-minutes設定とpermissions分離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv

--- a/.github/workflows/flaky-test-detection.yml
+++ b/.github/workflows/flaky-test-detection.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   flaky-test-detection:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
@@ -32,7 +33,7 @@ jobs:
         run: |
           uv run pytest tests/integration/ --flake-finder --flake-runs=5 -v
       - name: Create issue on failure
-        if: failure()
+        if: '!success()'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,13 +2,13 @@ name: Release Please
 on:
   push:
     branches: [main]
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -21,6 +21,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -39,6 +42,9 @@ jobs:
   publish-testpypi:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
     environment:
       name: testpypi
       url: https://test.pypi.org/project/yet-another-figma-mcp/
@@ -55,6 +61,9 @@ jobs:
   publish-pypi:
     needs: publish-testpypi
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/project/yet-another-figma-mcp/


### PR DESCRIPTION
## Summary\n\n- 全ワークフローの各ジョブに `timeout-minutes` を設定し、ハングしたジョブが長時間残ることを防止\n- `release-please.yml` の `permissions` をワークフローレベルからジョブレベルに分離し、各ジョブに必要最小限の権限のみ付与\n- `flaky-test-detection.yml` の issue 作成条件を `failure()` → `!success()` に変更し、タイムアウト時も issue が作成されるように改善\n\n### timeout-minutes 設定値\n\n| ワークフロー | ジョブ | timeout-minutes |\n|---|---|---|\n| ci.yml | test | 15 |\n| flaky-test-detection.yml | flaky-test-detection | 20 |\n| release-please.yml | release-please | 10 |\n| release-please.yml | build | 15 |\n| release-please.yml | publish-testpypi | 10 |\n| release-please.yml | publish-pypi | 10 |\n\n### permissions 分離（release-please.yml）\n\n| ジョブ | 変更前（全ジョブ共通） | 変更後（ジョブごと） |\n|---|---|---|\n| release-please | contents:write, pull-requests:write, id-token:write | contents:write, pull-requests:write |\n| build | 同上 | contents:read |\n| publish-testpypi | 同上 | id-token:write |\n| publish-pypi | 同上 | id-token:write |\n\nCloses #94, Closes #95\n\n## Test plan\n\n- [ ] CI ワークフローが正常に実行されることを確認\n- [ ] release-please ジョブが正しく動作することを確認（次回リリース時）\n- [ ] publish ジョブの `id-token: write` で Trusted Publisher が動作することを確認（次回リリース時）